### PR TITLE
Bind values as parameters in the local wallet database queries

### DIFF
--- a/src/api/db/database-manager.js
+++ b/src/api/db/database-manager.js
@@ -219,9 +219,10 @@ export class DatabaseManager {
 
   /**
    * Update data into the sqlite DB utilizing the query method
-   * @param {object} the table name, the columns to be updated, and an optional where clause
+   * @param {object} the table name, the columns to be updated, an optional where
+   * clause holding placeholders, and the values to bind to those placeholders
    */
-  update({ table, cols, where = null } = {}) {
+  update({ table, cols, where = null, whereParams = [] } = {}) {
     const setClause = this.flattenObjectToSetClause(cols);
     const whereClause = where
       ? `where ${where}`
@@ -229,31 +230,32 @@ export class DatabaseManager {
     const statement = `update ${table} set ${setClause} ${whereClause};`;
     return this.query({
       statement,
+      params: [...Object.values(cols), ...whereParams],
       run: true,
     });
   };
 
   /**
    * Execute a delete query into the sqlite DB
-   * @param {object} the table name, and an optional where clause
+   * @param {object} the table name, a where clause holding placeholders, and the
+   * values to bind to those placeholders
    */
-  delete({ table, where } = {}) {
+  delete({ table, where, whereParams = [] } = {}) {
     const statement = `delete from ${table} where ${where};`;
     return this.query({
       statement,
+      params: whereParams,
       run: true,
     });
   };
 
   /**
-   * Flatten the object into a single string to be used in the set clause.
+   * Flatten the object into a single string to be used in the set clause. Values
+   * are bound as parameters, so the clause only carries placeholders.
    * @param {object} data the data that needs to be flattened.
    */
   flattenObjectToSetClause(data) {
-    return Object.keys(data).map(key => {
-      const value = typeof data[key] === 'string' ? `'${data[key]}'` : data[key];
-      return `${key}=${value}`;
-    }).join(', ');
+    return Object.keys(data).map(key => `${key}=?`).join(', ');
   }
 
   /**
@@ -286,8 +288,10 @@ export class DatabaseManager {
    * @param {string} value - Value to search by
    */
   getContactsByValue(value = '') {
-    const statement = STMT.CONTACTS.SELECT.VALUE(value);
-    return this.query({ statement });
+    const statement = STMT.CONTACTS.SELECT.VALUE;
+    const searchValue = `${value}%`;
+
+    return this.query({ statement, params: [searchValue, searchValue] });
   }
 
   /**
@@ -296,8 +300,8 @@ export class DatabaseManager {
    * @param {string} contactAddress - the contact's address
    */
   async getFormattedContactName(contactAddress) {
-    const statement = STMT.CONTACTS.SELECT.FORMATTED_CONTACT_NAME(contactAddress);
-    const [res] = await this.query({ statement });
+    const statement = STMT.CONTACTS.SELECT.FORMATTED_CONTACT_NAME;
+    const [res] = await this.query({ statement, params: [contactAddress] });
 
     return res && res.name
       ? `${res.name} - (${contactAddress})`
@@ -313,7 +317,8 @@ export class DatabaseManager {
     return this.update({
       table: 'Contacts',
       cols,
-      where: `id=${id}`,
+      where: 'id=?',
+      whereParams: [id],
     });
   }
 
@@ -324,7 +329,8 @@ export class DatabaseManager {
   deleteContactById(id) {
     return this.delete({
       table: 'Contacts',
-      where: `id=${id}`,
+      where: 'id=?',
+      whereParams: [id],
     });
   }
 
@@ -349,8 +355,8 @@ export class DatabaseManager {
    * @param {String} receiver_address
    */
   getTransactionByDetails(txId, type) {
-    const statement = STMT.TRANSACTIONS.SELECT.TX_DETAILS(txId, type);
-    return this.query({ statement });
+    const statement = STMT.TRANSACTIONS.SELECT.TX_DETAILS;
+    return this.query({ statement, params: [txId, type] });
   }
 
   /**
@@ -359,8 +365,8 @@ export class DatabaseManager {
    */
   getTransactionsAfterDate(dateTime) {
     const filterDate = dateTime !== null ? dateTime : '1753-01-01';
-    const statement = STMT.TRANSACTIONS.SELECT.AFTER_DATE(filterDate);
-    return this.query({ statement });
+    const statement = STMT.TRANSACTIONS.SELECT.AFTER_DATE;
+    return this.query({ statement, params: [filterDate] });
   }
 
   /**
@@ -372,9 +378,21 @@ export class DatabaseManager {
   searchTransactionsForValue(addresses, value = '', dateTime) {
     const queryResults = [];
     const filterDate = dateTime !== null ? dateTime : '1753-01-01';
+    const searchValue = `%${value}%`;
+    const statement = STMT.TRANSACTIONS.SELECT.VALUE;
+
     addresses.forEach((addressData) => {
-      const statement = STMT.TRANSACTIONS.SELECT.VALUE(addressData.address, value, filterDate);
-      queryResults.push(this.query({ statement }));
+      const params = [
+        searchValue,
+        searchValue,
+        searchValue,
+        searchValue,
+        addressData.address,
+        addressData.address,
+        filterDate,
+      ];
+
+      queryResults.push(this.query({ statement, params }));
     });
 
     return Promise.all(queryResults).then((results) => {
@@ -385,10 +403,21 @@ export class DatabaseManager {
   searchTransactionsAndWalletsByValue(addresses, value = '', dateTime) {
     const queryResults = [];
     const filterDate = dateTime !== null ? dateTime : '1753-01-01';
+    const searchValue = `%${value}%`;
+    const statement = STMT.TRANSACTIONS.SELECT.INCLUDE_WALLETS_SEARCH_BY_VALUE;
 
     addresses.forEach((addressData) => {
-      const statement = STMT.TRANSACTIONS.SELECT.INCLUDE_WALLETS_SEARCH_BY_VALUE(addressData.address, value, filterDate);
-      queryResults.push(this.query({ statement }));
+      const params = [
+        searchValue,
+        searchValue,
+        searchValue,
+        searchValue,
+        addressData.address,
+        addressData.address,
+        filterDate,
+      ];
+
+      queryResults.push(this.query({ statement, params }));
     });
 
     return Promise.all(queryResults).then((results) => {
@@ -424,7 +453,8 @@ export class DatabaseManager {
     return this.update({
       table: 'Transactions',
       cols,
-      where: `transaction_id="${txId}"`,
+      where: 'transaction_id=?',
+      whereParams: [txId],
     });
   }
 
@@ -435,9 +465,9 @@ export class DatabaseManager {
    */
   getTransactionsPerAddressAfterDate(address = '', dateTime) {
     const filterDate = dateTime !== null ? dateTime : '1753-01-01';
-    const statement = STMT.TRANSACTIONS.SELECT.PER_ADDRESS(address, filterDate);
+    const statement = STMT.TRANSACTIONS.SELECT.PER_ADDRESS;
 
-    return this.query({ statement });
+    return this.query({ statement, params: [address, address, filterDate] });
   }
 
   /**
@@ -448,10 +478,16 @@ export class DatabaseManager {
    * @param {string} - receiver_address
    */
   async getTxAddressIds(sender_address, receiver_address) {
-    const senderStatement = STMT.ADDRESSES.SELECT.ADDRESS_ID(sender_address);
-    const receiverStatement = STMT.CONTACTS.SELECT.ADDRESS_ID(receiver_address);
-    const [{ id: sender_address_id }] = await this.query({ statement: senderStatement });
-    const [recipient = null] = await this.query({ statement: receiverStatement });
+    const senderStatement = STMT.ADDRESSES.SELECT.ADDRESS_ID;
+    const receiverStatement = STMT.CONTACTS.SELECT.ADDRESS_ID;
+    const [{ id: sender_address_id }] = await this.query({
+      statement: senderStatement,
+      params: [sender_address],
+    });
+    const [recipient = null] = await this.query({
+      statement: receiverStatement,
+      params: [receiver_address],
+    });
     const receiver_address_id = recipient ? recipient.id : null;
 
     return { sender_address_id, receiver_address_id };
@@ -478,7 +514,8 @@ export class DatabaseManager {
     this.update({
       table: 'Updates',
       cols,
-      where: `db_version=${lastVersion}`,
+      where: 'db_version=?',
+      whereParams: [lastVersion],
     });
   }
 
@@ -564,8 +601,8 @@ export class DatabaseManager {
     });
 
     wallets.forEach(async (wallet) => {
-      const addrStatement = STMT.ADDRESSES.SELECT.BY_WALLET_ID(wallet.id);
-      wallet.addresses = await this.query({ statement: addrStatement });
+      const addrStatement = STMT.ADDRESSES.SELECT.BY_WALLET_ID;
+      wallet.addresses = await this.query({ statement: addrStatement, params: [wallet.id] });
     });
 
     return wallets;
@@ -578,8 +615,8 @@ export class DatabaseManager {
    */
   async getWalletAddressesById(id) {
     const wallet = await this.getWalletById(id);
-    const statement = STMT.ADDRESSES.SELECT.BY_WALLET_ID(wallet.id);
-    wallet.addresses = await this.query({ statement });
+    const statement = STMT.ADDRESSES.SELECT.BY_WALLET_ID;
+    wallet.addresses = await this.query({ statement, params: [wallet.id] });
 
     return wallet;
   }
@@ -592,8 +629,12 @@ export class DatabaseManager {
    * @returns {Array.<WalletAddresses>} wallets
    */
   async getWalletAddressesByValue(value) {
-    const statement = STMT.WALLETS.SELECT.WALLET_ADDRESSES_BY_VALUE(value);
-    const res = await this.query({ statement });
+    const statement = STMT.WALLETS.SELECT.WALLET_ADDRESSES_BY_VALUE;
+    const searchValue = `${value}%`;
+    const res = await this.query({
+      statement,
+      params: [searchValue, searchValue, searchValue, searchValue],
+    });
     const wallets = {};
 
     res.forEach((obj) => {
@@ -634,8 +675,8 @@ export class DatabaseManager {
   }
 
   async getWalletNameByAddress(address) {
-    const statement = STMT.WALLETS.SELECT.NAME_BY_ADDRESS(address);
-    const [{ name }] = await this.query({ statement });
+    const statement = STMT.WALLETS.SELECT.NAME_BY_ADDRESS;
+    const [{ name }] = await this.query({ statement, params: [address] });
 
     return name;
   }
@@ -645,8 +686,8 @@ export class DatabaseManager {
    * @returns {Object} Wallet
    */
   async getWalletById(id) {
-    const statement = STMT.WALLETS.SELECT.ID(id);
-    const [res] = await this.query({ statement });
+    const statement = STMT.WALLETS.SELECT.ID;
+    const [res] = await this.query({ statement, params: [id] });
 
     return res;
   }
@@ -660,7 +701,8 @@ export class DatabaseManager {
     return this.update({
       table: 'Wallets',
       cols,
-      where: `id=${id}`,
+      where: 'id=?',
+      whereParams: [id],
     });
   }
 
@@ -684,8 +726,8 @@ export class DatabaseManager {
    */
 
   getAddressesByWalletId(id) {
-    const statement = STMT.ADDRESSES.SELECT.BY_WALLET_ID(id);
-    return this.query({ statement });
+    const statement = STMT.ADDRESSES.SELECT.BY_WALLET_ID;
+    return this.query({ statement, params: [id] });
   }
 
   /**
@@ -693,8 +735,8 @@ export class DatabaseManager {
    * @param {string} address - address value to query
    */
   async getBalanceByAddress(address) {
-    const statement = STMT.ADDRESSES.SELECT.BALANCE_BY_ADDRESS(address);
-    const [{ balance }] = await this.query({ statement });
+    const statement = STMT.ADDRESSES.SELECT.BALANCE_BY_ADDRESS;
+    const [{ balance }] = await this.query({ statement, params: [address] });
 
     return balance;
   }
@@ -704,8 +746,8 @@ export class DatabaseManager {
    * @param {string} address - address value to query
    */
   async getPrivKeyFromAddress(address) {
-    const statement = STMT.ADDRESSES.SELECT.PRIV_KEY_BY_ADDR(address);
-    const [{ private_key }] = await this.query({ statement });
+    const statement = STMT.ADDRESSES.SELECT.PRIV_KEY_BY_ADDR;
+    const [{ private_key }] = await this.query({ statement, params: [address] });
 
     return private_key;
   }
@@ -715,8 +757,8 @@ export class DatabaseManager {
    * @param {string} address - address value to query
    */
   async getAddressName(address) {
-    const statement = STMT.ADDRESSES.SELECT.FORMATTED_ADDRESS_NAME(address);
-    const [{ wallet_name, address_name = null }] = await this.query({ statement });
+    const statement = STMT.ADDRESSES.SELECT.FORMATTED_ADDRESS_NAME;
+    const [{ wallet_name, address_name = null }] = await this.query({ statement, params: [address] });
 
     return {
       walletName: wallet_name,
@@ -733,7 +775,8 @@ export class DatabaseManager {
     return this.update({
       table: 'Addresses',
       cols,
-      where: `id=${id}`,
+      where: 'id=?',
+      whereParams: [id],
     });
   }
 
@@ -744,7 +787,8 @@ export class DatabaseManager {
   deleteAddressById(id) {
     return this.delete({
       table: 'Addresses',
-      where: `id=${id}`,
+      where: 'id=?',
+      whereParams: [id],
     });
   }
 }

--- a/src/api/db/statements/addresses/index.js
+++ b/src/api/db/statements/addresses/index.js
@@ -40,17 +40,17 @@ export const ADDRESSES_STATEMENTS = {
     values(?,?,?,?,?,?,?,?)`,
   },
   SELECT: {
-    ADDRESS_ID: (addr) => `select id from Addresses where address="${addr}"`,
+    ADDRESS_ID: `select id from Addresses where address=?`,
     ALL: `select * from Addresses`,
-    BALANCE_BY_ADDRESS: (addr) => `select balance from Addresses where address="${addr}"`,
-    BY_WALLET_ID: (id) => `select * from Addresses where wallet_id=${id}`,
-    PRIV_KEY_BY_ADDR: (addr) => `select private_key from Addresses where address="${addr}"`,
-    FORMATTED_ADDRESS_NAME: (addr) => `
+    BALANCE_BY_ADDRESS: `select balance from Addresses where address=?`,
+    BY_WALLET_ID: `select * from Addresses where wallet_id=?`,
+    PRIV_KEY_BY_ADDR: `select private_key from Addresses where address=?`,
+    FORMATTED_ADDRESS_NAME: `
       select Wallets.name as wallet_name, Addresses.name as address_name
       from Wallets
       inner join Addresses
       on Wallets.id = Addresses.wallet_id
-      where Addresses.address="${addr}"
+      where Addresses.address=?
     `,
   },
 };

--- a/src/api/db/statements/contacts/index.js
+++ b/src/api/db/statements/contacts/index.js
@@ -33,9 +33,9 @@ export const CONTACTS_STATEMENTS = {
           values(?,?,?,?)`,
   },
   SELECT: {
-    ADDRESS_ID: (addr) => `select id from Contacts where address="${addr}"`,
+    ADDRESS_ID: `select id from Contacts where address=?`,
     ALL: `select * from Contacts`,
-    FORMATTED_CONTACT_NAME: (addr) => `select name from Contacts where address="${addr}"`,
-    VALUE: (value) => `select * from Contacts where name like "${value}%" or address like "${value}%"`,
+    FORMATTED_CONTACT_NAME: `select name from Contacts where address=?`,
+    VALUE: `select * from Contacts where name like ? or address like ?`,
   },
 };

--- a/src/api/db/statements/transactions/index.js
+++ b/src/api/db/statements/transactions/index.js
@@ -44,24 +44,24 @@ export const TRANSACTIONS_STATEMENTS = {
   },
   SELECT: {
     ALL: `select * from Transactions order by created_date desc`,
-    AFTER_DATE: (dateTime) => `select * from Transactions where created_date >= "${dateTime}" order by created_date desc`,
-    PER_ADDRESS: (address, dateTime) => `select * from Transactions where (sender_address = "${address}" or receiver_address = "${address}") and created_date >= "${dateTime}" order by created_date desc`,
-    VALUE: (address, value, dateTime) => `
+    AFTER_DATE: `select * from Transactions where created_date >= ? order by created_date desc`,
+    PER_ADDRESS: `select * from Transactions where (sender_address = ? or receiver_address = ?) and created_date >= ? order by created_date desc`,
+    VALUE: `
       select Transactions.*, Addresses.name from Transactions
       left join Addresses on (receiver_address = Addresses.address
       or sender_address = Addresses.address)
-      where (description like "%${value}%" or amount like "%${value}%"
-      or Transactions.created_date like "%${value}%" or name like "%${value}%") and (sender_address = "${address}"
-      or receiver_address = "${address}") and Transactions.created_date >= "${dateTime}" order by created_date desc`,
-    INCLUDE_WALLETS_SEARCH_BY_VALUE: (address, value, dateTime) => `
+      where (description like ? or amount like ?
+      or Transactions.created_date like ? or name like ?) and (sender_address = ?
+      or receiver_address = ?) and Transactions.created_date >= ? order by created_date desc`,
+    INCLUDE_WALLETS_SEARCH_BY_VALUE: `
       select Transactions.*, Addresses.wallet_id, Wallets.name from Transactions
       inner join Addresses on (receiver_address = Addresses.address
       or sender_address = Addresses.address)
       left join Wallets on Addresses.wallet_id = Wallets.id
-      where (Transactions.description like "%${value}%" or amount like "%${value}%"
-      or Transactions.created_date like "%${value}%" or Wallets.name like "%${value}%") and (sender_address = "${address}"
-      or receiver_address = "${address}") and Transactions.created_date >= "${dateTime}" order by created_date desc`,
-    TX_DETAILS: (txId, type) => (`
-      select * from Transactions where transaction_id="${txId}" and transaction_type="${type}"`),
+      where (Transactions.description like ? or amount like ?
+      or Transactions.created_date like ? or Wallets.name like ?) and (sender_address = ?
+      or receiver_address = ?) and Transactions.created_date >= ? order by created_date desc`,
+    TX_DETAILS: `
+      select * from Transactions where transaction_id=? and transaction_type=?`,
   },
 };

--- a/src/api/db/statements/wallets/index.js
+++ b/src/api/db/statements/wallets/index.js
@@ -39,22 +39,22 @@ export const WALLETS_STATEMENTS = {
   },
   SELECT: {
     ALL: `select * from Wallets`,
-    ID: (id) => `select * from Wallets where id = ${id}`,
+    ID: `select * from Wallets where id = ?`,
     NAME: `select id, name from Wallets`,
-    NAME_BY_ADDRESS: (addr) => `
+    NAME_BY_ADDRESS: `
       select Wallets.name as name from Wallets
       inner join Addresses
       on Wallets.id = Addresses.wallet_id
-      where Addresses.address="${addr}"
+      where Addresses.address=?
     `,
-    WALLET_ADDRESSES_BY_VALUE: (value) => `
+    WALLET_ADDRESSES_BY_VALUE: `
         select Wallets.id, Wallets.name as wallet_name,
         Addresses.id as address_id, Addresses.name as address_name, Addresses.address, Addresses.balance
         from Wallets
         inner join Addresses
         on Wallets.id = Addresses.wallet_id
-        where Wallets.name like "${value}%" or Addresses.name like "${value}%"
-        or Addresses.balance like "${value}%" or Addresses.address like "${value}%"
+        where Wallets.name like ? or Addresses.name like ?
+        or Addresses.balance like ? or Addresses.address like ?
       `,
   },
 };

--- a/tests/unit/api/db/database-manager.unit.test.js
+++ b/tests/unit/api/db/database-manager.unit.test.js
@@ -1,0 +1,341 @@
+/**
+* MIT License
+*
+* Copyright (c) 2020 Code Particle Inc.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+import { DatabaseManager } from 'api/db/database-manager';
+
+const SEED = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+const PRIVATE_KEY = 'f0e1d2c3b4a5968778695a4b3c2d1e0f';
+const TX_DATE = '2020-01-02 10:00:00';
+
+async function setupDb() {
+  const databaseManager = new DatabaseManager();
+
+  await databaseManager.generateTables();
+  await databaseManager.insert().wallet({
+    id: 1,
+    name: 'Savings',
+    coin_id: 1,
+    multi_address: 0,
+    require_password: 0,
+    password_hash: 'hashed-password',
+    seed: SEED,
+    address_index: 0,
+  });
+  await databaseManager.insert().address({
+    id: 1,
+    wallet_id: 1,
+    address: 'address-one',
+    private_key: PRIVATE_KEY,
+    name: 'Primary',
+    is_active: 1,
+    balance: 1.5,
+    parent_id: null,
+  });
+  await databaseManager.insert().contact({
+    id: 1,
+    name: 'Alice',
+    address: 'address-alice',
+    description: 'friend',
+  });
+  await databaseManager.insert().transaction({
+    id: 1,
+    sender_address_id: 1,
+    receiver_address_id: null,
+    amount: 0.25,
+    fee: 0.0001,
+    transaction_id: 'tx-one',
+    description: 'Coffee',
+    sender_address: 'address-one',
+    receiver_address: 'address-alice',
+    status: 1,
+    created_date: TX_DATE,
+    transaction_type: 'send',
+  });
+
+  return databaseManager;
+}
+
+describe('DatabaseManager', () => {
+  let databaseManager;
+
+  beforeEach(async () => {
+    databaseManager = await setupDb();
+  });
+
+  afterEach(() => {
+    databaseManager.db.close();
+  });
+
+  describe('getContactsByValue', () => {
+    it('matches contacts by the start of their name', async () => {
+      const res = await databaseManager.getContactsByValue('Ali');
+
+      expect(res).toHaveLength(1);
+      expect(res[0].name).toEqual('Alice');
+    });
+
+    it('treats a search value containing a double quote as data', async () => {
+      const res = await databaseManager.getContactsByValue('Jean "Ace" Doe');
+
+      expect(res).toEqual([]);
+    });
+
+    it('does not let a search value select columns of another table', async () => {
+      const res = await databaseManager.getContactsByValue(
+        '" union select id, name, seed, description from Wallets --'
+      );
+
+      expect(JSON.stringify(res)).not.toContain(SEED);
+    });
+  });
+
+  describe('getWalletAddressesByValue', () => {
+    it('matches wallets by the start of their name', async () => {
+      const res = await databaseManager.getWalletAddressesByValue('Sav');
+
+      expect(res).toHaveLength(1);
+      expect(res[0].name).toEqual('Savings');
+    });
+
+    it('does not let a search value select the stored private keys', async () => {
+      const res = await databaseManager.getWalletAddressesByValue(
+        '" union select id, private_key, id, name, address, balance from Addresses --'
+      );
+
+      expect(JSON.stringify(res)).not.toContain(PRIVATE_KEY);
+    });
+  });
+
+  describe('searchTransactionsForValue', () => {
+    it('matches transactions on any part of their description', async () => {
+      const res = await databaseManager.searchTransactionsForValue(
+        [{ address: 'address-one' }],
+        'offe',
+        null
+      );
+
+      expect(res).toHaveLength(1);
+      expect(res[0].transaction_id).toEqual('tx-one');
+    });
+
+    it('treats a search value containing a double quote as data', async () => {
+      const res = await databaseManager.searchTransactionsForValue(
+        [{ address: 'address-one' }],
+        'Jean "Ace" Doe',
+        null
+      );
+
+      expect(res).toEqual([]);
+    });
+  });
+
+  describe('searchTransactionsAndWalletsByValue', () => {
+    it('matches transactions on the name of their wallet', async () => {
+      const res = await databaseManager.searchTransactionsAndWalletsByValue(
+        [{ address: 'address-one' }],
+        'Savings',
+        null
+      );
+
+      expect(res).toHaveLength(1);
+      expect(res[0].transaction_id).toEqual('tx-one');
+    });
+  });
+
+  describe('date filtered transaction queries', () => {
+    it('returns transactions created after the given date', async () => {
+      expect(await databaseManager.getTransactionsAfterDate('2019-01-01')).toHaveLength(1);
+      expect(await databaseManager.getTransactionsAfterDate('2021-01-01')).toHaveLength(0);
+    });
+
+    it('returns transactions for an address after the given date', async () => {
+      expect(await databaseManager.getTransactionsPerAddressAfterDate('address-one', '2019-01-01')).toHaveLength(1);
+      expect(await databaseManager.getTransactionsPerAddressAfterDate('address-two', '2019-01-01')).toHaveLength(0);
+    });
+  });
+
+  describe('getTransactionByDetails', () => {
+    it('returns the transaction matching both the id and the type', async () => {
+      expect(await databaseManager.getTransactionByDetails('tx-one', 'send')).toHaveLength(1);
+      expect(await databaseManager.getTransactionByDetails('tx-one', 'receive')).toHaveLength(0);
+    });
+  });
+
+  describe('updateTxByTxId', () => {
+    it('updates only the transaction with the given id', async () => {
+      await databaseManager.updateTxByTxId('tx-one', { description: 'Tea' });
+
+      const [transaction] = await databaseManager.getTransactionByDetails('tx-one', 'send');
+      expect(transaction.description).toEqual('Tea');
+    });
+  });
+
+  describe('getTxAddressIds', () => {
+    it('returns the address id of the sender and the contact id of the receiver', async () => {
+      const res = await databaseManager.getTxAddressIds('address-one', 'address-alice');
+
+      expect(res).toEqual({ sender_address_id: 1, receiver_address_id: 1 });
+    });
+  });
+
+  describe('updateContactById', () => {
+    it('stores a name containing a single quote verbatim', async () => {
+      await databaseManager.updateContactById(1, { name: "Sam O'Neil" });
+
+      const [contact] = await databaseManager.getContacts();
+      expect(contact.name).toEqual("Sam O'Neil");
+    });
+
+    it('does not run a statement embedded in a contact field', async () => {
+      await databaseManager.updateContactById(1, {
+        name: "Mallory'; delete from Wallets; --",
+      });
+
+      const wallets = await databaseManager.getWallets();
+      expect(wallets).toHaveLength(1);
+    });
+  });
+
+  describe('getFormattedContactName', () => {
+    it('formats the name of a known contact', async () => {
+      expect(await databaseManager.getFormattedContactName('address-alice')).toEqual('Alice - (address-alice)');
+    });
+
+    it('falls back to the address of an unknown contact', async () => {
+      expect(await databaseManager.getFormattedContactName('address-bob')).toEqual('address-bob');
+    });
+  });
+
+  describe('deleteContactById', () => {
+    it('deletes only the contact with the given id', async () => {
+      await databaseManager.insert().contact({
+        id: 2,
+        name: 'Bob',
+        address: 'address-bob',
+        description: '',
+      });
+      await databaseManager.deleteContactById(1);
+
+      const contacts = await databaseManager.getContacts();
+      expect(contacts).toHaveLength(1);
+      expect(contacts[0].name).toEqual('Bob');
+    });
+  });
+
+  describe('getWalletById', () => {
+    it('returns the matching wallet', async () => {
+      const wallet = await databaseManager.getWalletById(1);
+
+      expect(wallet.name).toEqual('Savings');
+    });
+  });
+
+  describe('getWalletAddressesById', () => {
+    it('returns the wallet with its addresses', async () => {
+      const wallet = await databaseManager.getWalletAddressesById(1);
+
+      expect(wallet.name).toEqual('Savings');
+      expect(wallet.addresses).toHaveLength(1);
+      expect(wallet.addresses[0].address).toEqual('address-one');
+    });
+  });
+
+  describe('getWalletNameByAddress', () => {
+    it('returns the name of the wallet holding the address', async () => {
+      expect(await databaseManager.getWalletNameByAddress('address-one')).toEqual('Savings');
+    });
+  });
+
+  describe('updateWalletById', () => {
+    it('updates only the wallet with the given id', async () => {
+      await databaseManager.updateWalletById(1, { name: 'Rainy Day', address_index: 3 });
+
+      const wallet = await databaseManager.getWalletById(1);
+      expect(wallet.name).toEqual('Rainy Day');
+      expect(wallet.address_index).toEqual(3);
+    });
+  });
+
+  describe('getPrivKeyFromAddress', () => {
+    it('returns the private key stored for the address', async () => {
+      const privateKey = await databaseManager.getPrivKeyFromAddress('address-one');
+
+      expect(privateKey).toEqual(PRIVATE_KEY);
+    });
+  });
+
+  describe('getBalanceByAddress', () => {
+    it('returns the balance stored for the address', async () => {
+      expect(await databaseManager.getBalanceByAddress('address-one')).toEqual(1.5);
+    });
+  });
+
+  describe('getAddressName', () => {
+    it('returns the wallet name and the address name', async () => {
+      expect(await databaseManager.getAddressName('address-one')).toEqual({
+        walletName: 'Savings',
+        addressName: 'Primary',
+      });
+    });
+  });
+
+  describe('getAddressesByWalletId', () => {
+    it('returns the addresses of the given wallet', async () => {
+      expect(await databaseManager.getAddressesByWalletId(1)).toHaveLength(1);
+      expect(await databaseManager.getAddressesByWalletId(2)).toHaveLength(0);
+    });
+  });
+
+  describe('updateAddressById', () => {
+    it('updates only the address with the given id', async () => {
+      await databaseManager.updateAddressById(1, { balance: 2.75 });
+
+      expect(await databaseManager.getBalanceByAddress('address-one')).toEqual(2.75);
+    });
+  });
+
+  describe('deleteAddressById', () => {
+    it('deletes only the address with the given id', async () => {
+      await databaseManager.deleteAddressById(1);
+
+      expect(await databaseManager.getAddresses()).toHaveLength(0);
+    });
+  });
+
+  describe('updateUserTheme', () => {
+    it('updates the theme when the statement has no where clause', async () => {
+      await databaseManager.updateUserTheme('dark');
+
+      const settings = await databaseManager.getUserSettings();
+      expect(settings.theme).toEqual('dark');
+    });
+  });
+
+  describe('updateDbVersion', () => {
+    it('updates the row matching the previous version', async () => {
+      await databaseManager.updateDbVersion({ db_version: 191115 }, 0);
+
+      expect(await databaseManager.getCurrentVersion()).toEqual(191115);
+    });
+  });
+});


### PR DESCRIPTION
This PR proposes binding caller-supplied values as SQL parameters in the local wallet database layer, so that a search term or a contact field can no longer change the statement that runs against the wallet's sqlite file. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/275. You can sign in with your GitHub ID to claim ownership of the project.

## What is happening today

Most statements in `src/api/db/statements/*` are built by interpolating the caller's value into the SQL string — for example `select * from Contacts where name like "${value}%" or address like "${value}%"` — and `DatabaseManager.update()` does the same for column values, via `flattenObjectToSetClause` wrapping strings in single quotes.

Those values arrive straight from the UI. `SearchContacts` passes what the user typed into `searchContactsByValue` → `databaseManager.getContactsByValue`; the send-funds and receive-funds address lists do the same through `getWalletAddressesByValue`; transaction search reaches `searchTransactionsForValue`; the contact and wallet sidepanels pass their form fields to `updateContactById` / `updateWalletById`; and `updateTxByTxId` uses a transaction id that came back from the explorer API.

Three things follow from that, in increasing order of seriousness. A value containing a quote character produces a syntax error, so searching for `Jean "Ace" Doe` or saving a contact named `Sam O'Neil` rejects the query and the search results or the save silently do nothing. A crafted search value can select from another table, and the result rows are rendered in the list — the search path returns rows through `db.prepare`, so a `union select` reaches the seed and private key columns of `Wallets` and `Addresses`. And an update reaches `db.run` without params, which runs every statement in the string, so a contact field is enough to execute a second statement of the attacker's choosing.

## Reproduction on master

Against `master` at 2a3b646, with only `tests/unit/api/db/database-manager.unit.test.js` from this branch added and `src/` untouched, `yarn run test:unit` reports:

```
✕ treats a search value containing a double quote as data
✕ does not let a search value select columns of another table
✕ does not let a search value select the stored private keys
✕ treats a search value containing a double quote as data
✕ stores a name containing a single quote verbatim
✕ does not run a statement embedded in a contact field
Tests: 6 failed, 24 passed, 30 total
```

The two that matter most: `getContactsByValue('" union select id, name, seed, description from Wallets --')` comes back with the wallet's mnemonic seed in the contact result set, and `updateContactById(1, { name: "Mallory'; delete from Wallets; --" })` leaves the `Wallets` table empty.

## The change

The `SELECT` entries that took a value are now constants holding `?` placeholders instead of functions that interpolate one, and every caller-supplied value is bound through the `params` path that `DatabaseManager.query()` already implements and documents. `update()` and `delete()` take the values for their where clause the same way, through a new optional `whereParams`, and `flattenObjectToSetClause` now emits `col=?` and lets the values bind. Nothing new was added to the dependency list — `sqlstring-sqlite` is already declared but not imported anywhere, and binding through the existing `query()` path makes it unnecessary.

`DatabaseManager` is the only consumer of `STATEMENTS` in the repo, so no other caller changes shape. `LIKE` semantics are preserved exactly: the `%` wildcards are appended to the bound value, in the same prefix or substring position each statement used before.

## Verification

`tests/unit/api/db/database-manager.unit.test.js` adds 30 assertions covering every query method the change touches: the 6 above fail without the `src/` half of this branch and pass with it, and the other 24 pass on both trees — they are the controls that the legitimate behaviour did not move (prefix search still matches, date filters still filter, updates and deletes still hit exactly one row, `getTxAddressIds`, `getAddressName`, `getBalanceByAddress`, `getPrivKeyFromAddress` and the theme and db-version updates all still return what they did before).

On this branch the full unit suite is green — `Tests: 34 passed, 34 total`, the 4 that existed plus these 30 — run with node 14 to match `.github/workflows/test.yml`. `yarn run lint` behaves the same before and after: it stops at the same `TypeError: Cannot read property 'range' of null` inside eslint's `template-curly-spacing` rule that master already hits on multi-line template literals, which is untouched by this change.

## How this was managed

We track this work on a live board built from your repo's own issues and pull requests: this change is the story [Bind SQL parameters in the local wallet database queries](https://eastagiletracker.com/projects/275/stories/168870), on the board at https://eastagiletracker.com/projects/275.

![board](https://raw.githubusercontent.com/eastagiletracker/whitelabelwallet/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
